### PR TITLE
Check children is not null

### DIFF
--- a/src/RevealBase.js
+++ b/src/RevealBase.js
@@ -394,7 +394,7 @@ class RevealBase extends React.Component {
   getChild() {
     if (this.savedChild && !this.props.disabled)
       return this.savedChild;
-    if (typeof this.props.children === 'object') {
+    if (this.props.children && typeof this.props.children === 'object') {
        const child = React.Children.only(this.props.children);
        return  (('type' in child) && typeof child.type === 'string') || this.props.refProp !== 'ref'
                ? child


### PR DESCRIPTION
Javascript believes that null is an object. If children is `null`, the evaluation of `typeof this.props.children === 'object' returns `true`.

When evaluating the next line, `typeof child.type === 'string'` the script crashes because it can't check `type` of `null`.